### PR TITLE
fix: Lowercase properties in token info display

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -80,7 +80,7 @@ function goToAuthPage() {
         .then(response => {
             let responseBody = response.split("<body>")[1].split("</body>")[0];
             let bodyElement = document.createElement("div");
-          bodyElement.innerHTML = responseBody;
+            bodyElement.innerHTML = responseBody;
 
             authcode = bodyElement.querySelector('.infobox h4').innerText;
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -80,7 +80,7 @@ function goToAuthPage() {
         .then(response => {
             let responseBody = response.split("<body>")[1].split("</body>")[0];
             let bodyElement = document.createElement("div");
-            bodyElement.innerHTML = responseBody;
+          bodyElement.innerHTML = responseBody;
 
             authcode = bodyElement.querySelector('.infobox h4').innerText;
 
@@ -97,7 +97,12 @@ function goToAuthPage() {
                 const generateTokenButton = document.querySelector('#generate-token');
                 generateTokenButton.style.display = 'none';
 
-                let tokenInfo = JSON.stringify(res.tokeninfo[0], null, 2);
+                let tokenInfo = JSON.stringify(res.tokeninfo[0], null, 2)
+                  .replace("ACCESS_TOKEN", "access_token")
+                  .replace("CLIENT", "client")
+                  .replace("SECRET", "secret")
+                  .replace("AUTHCODE", "authcode")
+                  .replace("REFRESH_TOKEN", "refresh_token");
 
                 let access_token_macro = chunkString(res.tokeninfo[0].ACCESS_TOKEN, 240).join('%trim(\r\n)');
                 let refresh_token_macro = chunkString(res.tokeninfo[0].REFRESH_TOKEN, 240).join('%trim(\r\n)');


### PR DESCRIPTION
Display token info with lowercase property names to make copy-paste easier.